### PR TITLE
Make migrate.sh more reliable and reproducible

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -4,13 +4,24 @@ set -e
 POSTGRES_HOST=${POSTGRES_HOST:-"localhost"}
 POSTGRES_PORT=${POSTGRES_PORT:-"5432"}
 
-cd /app/
-
 sleep 2 # wait for postgres to start
 
-PYTHON_BIN=/opt/venv/bin/python
+[ -d /app/ ] && cd /app/
 
+PYTHON_BIN="/opt/venv/bin/python"
+[ ! -f "$PYTHON_BIN" ] && PYTHON_BIN="python"
+
+# Run migrations and create superuser
 $PYTHON_BIN src/manage.py makemigrations --noinput
 $PYTHON_BIN src/manage.py migrate --noinput
 
-$PYTHON_BIN src/manage.py createsuperuser --noinput || true
+SUPERUSER_EXISTS=$($PYTHON_BIN src/manage.py shell -c "
+import os
+from dotenv import load_dotenv
+from apps.users.models import User
+
+load_dotenv()
+print(User.objects.filter(email=os.getenv('DJANGO_SUPERUSER_EMAIL')).exists())
+")
+
+[ "$SUPERUSER_EXISTS" != "True" ] && $PYTHON_BIN src/manage.py createsuperuser --noinput || true


### PR DESCRIPTION
Due to run migrate.sh script not only in container but locally, we should check if exists working directory /app/. And also to prevent the error that user is already exist, before create check if the user already exist